### PR TITLE
Bugfix: Blobs singing duplicate notes

### DIFF
--- a/src/midi-to-blob.js
+++ b/src/midi-to-blob.js
@@ -33,7 +33,7 @@ class MidiToBlob {
   getNoteEvents () {
 
     return this.player.getEvents()
-    .map(track => track.filter(event => [`Note on`, `Note off`].includes(event.name)))
+    .map(track => track.filter(event => [`Note on`].includes(event.name)))
     .filter(track => !_.isEmpty(track))
   }
 

--- a/src/midi-to-blob.js
+++ b/src/midi-to-blob.js
@@ -33,7 +33,7 @@ class MidiToBlob {
   getNoteEvents () {
 
     return this.player.getEvents()
-    .map(track => track.filter(event => [`Note on`].includes(event.name)))
+    .map(track => track.filter(event => [`Note on`, `Note off`].includes(event.name)))
     .filter(track => !_.isEmpty(track))
   }
 
@@ -70,7 +70,7 @@ class MidiToBlob {
 
       return track.reduce((memo, event, index, allEvents) => {
 
-        if (!event.velocity) {
+        if (!event.velocity || event.name === `Note off`) {
 
           return memo
         }


### PR DESCRIPTION
The `getNoteEvents` function collects notes on both: "Note on" and "Note off" events. This results in the Blobs singing every note twice. I think this should only be on "Note on" events.